### PR TITLE
:bug: Fix perceived position of plots

### DIFF
--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -128,7 +128,8 @@ export class Plot extends Rect {
   }
 
   protected drawShape(context: CanvasRenderingContext2D): void {
-    const tl = this.topLeft().add(this.edgePadding().mul([1, 0]));
+    const halfSize = this.computedSize().mul(0.5);
+    const tl = this.edgePadding().mul([1, 0]).sub(halfSize);
 
     for (let i = 0; i <= this.ticks().floored.x; i++) {
       const startPosition = tl.add(
@@ -225,8 +226,8 @@ export class Plot extends Rect {
     context.textAlign = 'center';
     context.fillText(
       this.xAxisLabel(),
-      this.bottom().x + this.edgePadding().x / 2,
-      this.bottom().y - this.labelPadding().x / 2,
+      this.edgePadding().x / 2,
+      halfSize.y - this.labelPadding().x / 2,
     );
 
     // Draw rotated Y axis label
@@ -235,8 +236,8 @@ export class Plot extends Rect {
     context.textAlign = 'center';
     context.save();
     context.translate(
-      this.left().x + this.labelPadding().y / 2 + this.labelSize().y,
-      this.left().y - this.edgePadding().y / 2,
+      -halfSize.x + this.labelPadding().y / 2 + this.labelSize().y,
+      -this.edgePadding().y / 2,
     );
     context.rotate(-Math.PI / 2);
     context.fillText(this.yAxisLabel(), 0, 0);
@@ -244,9 +245,12 @@ export class Plot extends Rect {
   }
 
   public getPointFromPlotSpace(point: PossibleVector2) {
-    const bottomLeft = this.bottomLeft().add(this.edgePadding().mul([1, -1]));
-    const delta = this.topRight().sub(bottomLeft);
-    return bottomLeft.add(this.toRelativeGridSize(point).mul(delta));
+    const topRight = this.computedSize().mul([0.5, -0.5]);
+    const edgePadding = this.edgePadding().mul([1, -1]);
+    const offset = edgePadding.sub(topRight);
+    const graphSize = topRight.sub(offset);
+
+    return this.toRelativeGridSize(point).mul(graphSize).add(offset);
   }
 
   private mapToX(value: number) {


### PR DESCRIPTION
Updates the `drawShape` function to avoid using cardinal points.
Cardinal points return positions in *parent* space. 
This works as intended when the plot's position and offset are set to `0`, but it breaks as soon as the plot is moved:

### Custom position
|Before|After|
| --- | --- |
|![image](https://github.com/hhenrichsen/motion-canvas-graphing/assets/64662184/54379836-b645-48b5-a37b-61b391c3bad7)|![image](https://github.com/hhenrichsen/motion-canvas-graphing/assets/64662184/8c9147c0-7df7-42de-96c4-cb493afe5034)|

<details>
<summary>Repro code</summary>

```ts
import { makeScene2D } from "@motion-canvas/2d";
import {
  createRef,
  range,
  useRandom,
} from "@motion-canvas/core";
import {
  Plot,
  LinePlot,
} from "@hhenrichsen/motion-canvas-graphing";

export default makeScene2D(function* (view) {
  const random = useRandom();

  const plot = createRef<Plot>();
  view.add(
    <LinePlot
      size={500}
      ref={plot}
      xAxisLabel="Time"
      yAxisLabel="Beans"
      position={[200, 100]}
      graphWidth={4}
      graphColor={"lightseagreen"}
      data={range(0, 26).map((i) => [i * 4, random.nextInt(0, 100)])}
    />
  );
});
```

</details>

### Custom offset
|Before|After|
| --- | --- |
|![image](https://github.com/hhenrichsen/motion-canvas-graphing/assets/64662184/9a94fdcd-ed95-4456-8fe0-d8a23b1b4274)|![image](https://github.com/hhenrichsen/motion-canvas-graphing/assets/64662184/70432ae3-cdff-411c-abe2-05fe2372170d)|

<details>
<summary>Repro code</summary>

```ts
import { makeScene2D } from "@motion-canvas/2d";
import {
  createRef,
  range,
  useRandom,
} from "@motion-canvas/core";
import {
  Plot,
  LinePlot,
} from "@hhenrichsen/motion-canvas-graphing";

export default makeScene2D(function* (view) {
  const random = useRandom();

  const plot = createRef<Plot>();
  view.add(
    <LinePlot
      size={500}
      ref={plot}
      xAxisLabel="Time"
      yAxisLabel="Beans"
      offsetX={-1}
      graphWidth={4}
      graphColor={"lightseagreen"}
      data={range(0, 26).map((i) => [i * 4, random.nextInt(0, 100)])}
    />
  );
});
```

</details>

