### PR TITLE
:bug: Fix centering of tick labels

### DIFF
--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -174,7 +174,8 @@ export class Plot extends Layout {
 
       context.fillStyle = resolveCanvasStyle(this.xAxisTextColor(), context);
       context.font = `${this.tickLabelSize().y}px sans-serif`;
-      context.textAlign = 'right';
+      context.textAlign = 'center';
+      context.textBaseline = 'top';
       context.fillText(
         `${this.xLabelFormatter(this.mapToX(i / this.ticks().x))}`,
         startPosition.x,
@@ -203,13 +204,14 @@ export class Plot extends Layout {
       context.fillStyle = resolveCanvasStyle(this.yAxisTextColor(), context);
       context.font = `${this.tickLabelSize().y}px ${this.fontFamily()}`;
       context.textAlign = 'right';
+      context.textBaseline = 'middle';
       context.fillText(
         `${this.yLabelFormatter(this.mapToY(i / this.ticks().y))}`,
         tl.x -
           this.tickLabelSize().y -
           this.tickOverflow().y -
           this.axisStrokeWidth().y,
-        startPosition.y + this.tickLabelSize().y / 2,
+        startPosition.y,
       );
     }
 
@@ -247,6 +249,7 @@ export class Plot extends Layout {
     context.fillStyle = resolveCanvasStyle(this.xAxisTextColor(), context);
     context.font = `${this.labelSize().y}px ${this.fontFamily()}`;
     context.textAlign = 'center';
+    context.textBaseline = 'alphabetic';
     context.fillText(
       this.xAxisLabel(),
       this.edgePadding().x / 2,
@@ -257,6 +260,7 @@ export class Plot extends Layout {
     context.fillStyle = resolveCanvasStyle(this.yAxisTextColor(), context);
     context.font = `${this.labelSize().y}px ${this.fontFamily()}`;
     context.textAlign = 'center';
+    context.textBaseline = 'alphabetic';
     context.save();
     context.translate(
       -halfSize.x + this.labelPadding().y / 2 + this.labelSize().y,


### PR DESCRIPTION
Aligns the horizontal tick labels to match the vertical ones.
(Feel free to ignore this PR if the current right alignment is a desired stylistic choice)
|Before|After|
| --- | --- |
|![image](https://github.com/hhenrichsen/motion-canvas-graphing/assets/64662184/5dd40e7b-696c-4de2-8fec-129be79848d1)|![image](https://github.com/hhenrichsen/motion-canvas-graphing/assets/64662184/3fc8dbb6-d740-481b-8b2f-12ae6f05e915)|
