### PR TITLE
v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,54 +29,57 @@ import {createRef, linear, waitFor} from '@motion-canvas/core';
 
 export default makeScene2D(function* (view) {
   const random = useRandom();
-
-  const plot = createRef<LinePlot>();
+  const plot = createRef<Plot>();
+  const scatter = createRef<ScatterPlot>();
   view.add(
-    <LinePlot
+    <Plot
+      size={500}
+      ref={plot}
+      labelX="Time"
+      labelY="Errors"
+      labelSize={10}
+      opacity={0}
+    >
+      <ScatterPlot
+        pointRadius={5}
+        pointColor={'red'}
+        ref={scatter}
+        end={0}
+        data={range(0, 26).map(i => [i * 4, random.nextInt(0, 100)])}
+      />
+    </Plot>,
+  );
+
+  yield* plot().opacity(1, 2);
+  yield* waitFor(2);
+  yield scatter().end(1, 3, linear);
+  yield* waitFor(2);
+  yield* plot().opacity(0, 2);
+
+  const plot2 = createRef<Plot>();
+  const line2 = createRef<LinePlot>();
+  view.add(
+    <Plot
       clip
       size={500}
-      ref={plot4}
+      ref={plot2}
       labelSize={0}
-      graphWidth={4}
-      graphColor={'red'}
       minX={-10}
       maxX={10}
       minY={-2}
       maxY={50}
-      end={0}
       opacity={0}
       ticks={[4, 4]}
-    />,
+      offset={[-1, 0]}
+    >
+      <LinePlot lineWidth={4} stroke={'red'} ref={line2} />
+    </Plot>,
   );
 
-  yield* plot().opacity(1, 2);
-  plot().data(plot().makeGraphData(0.1, x => Math.pow(x, 2)));
-  yield* plot().end(1, 3, linear);
-  yield* waitFor(2);
-  yield* plot().opacity(0, 2);
-
-  plot().remove();
-
-  const plot2 = createRef<ScatterPlot>();
-  view.add(
-    <ScatterPlot
-      size={500}
-      ref={plot3}
-      xAxisLabel="Time"
-      yAxisLabel="Errors"
-      labelSize={10}
-      pointRadius={5}
-      pointColor={'red'}
-      end={0}
-      opacity={0}
-      data={range(0, 26).map(i => [i * 4, random.nextInt(0, 100)])}
-    />,
-  );
-
+  line2().data(plot2().makeGraphData(0.1, x => Math.pow(x, 2)));
   yield* plot2().opacity(1, 2);
-  yield* plot2().end(1, 3, linear);
   yield* waitFor(2);
-  yield* plot2().opacity(0, 2);
+  yield* line2().end(1, 1);
 
   yield* waitFor(5);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hhenrichsen/motion-canvas-graphing",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Some graphing components for Motion Canvas.",
   "scripts": {
     "prepare": "husky install",

--- a/src/LinePlot.tsx
+++ b/src/LinePlot.tsx
@@ -1,80 +1,36 @@
-import {
-  initial,
-  signal,
-  resolveCanvasStyle,
-  canvasStyleSignal,
-  CanvasStyleSignal,
-  PossibleCanvasStyle,
-  computed,
-} from '@motion-canvas/2d';
-import {SimpleSignal, range} from '@motion-canvas/core';
-import {Plot, PlotProps} from './Plot';
+import {signal, Line, LineProps} from '@motion-canvas/2d';
+import {BBox, SimpleSignal, Vector2, useLogger} from '@motion-canvas/core';
+import {Plot} from './Plot';
 
-export interface LinePlotProps extends PlotProps {
-  graphWidth?: number;
-  graphColor?: PossibleCanvasStyle;
+export interface LinePlotProps extends LineProps {
   data?: [number, number][];
-  end?: number;
+  points?: never;
 }
 
-export class LinePlot extends Plot {
-  @initial(1)
-  @signal()
-  public declare readonly graphWidth: SimpleSignal<number, this>;
-
-  @initial('white')
-  @canvasStyleSignal()
-  public declare readonly graphColor: CanvasStyleSignal<this>;
-
+export class LinePlot extends Line {
   @signal()
   public declare readonly data: SimpleSignal<[number, number][], this>;
 
-  @initial(1)
-  @signal()
-  public declare readonly end: SimpleSignal<number, this>;
-
-  @computed()
-  private lastIndex() {
-    return Math.floor(
-      this.data().length * Math.min(Math.max(0, this.end()), 1) - 1,
-    );
-  }
-
   public constructor(props?: LinePlotProps) {
-    super(props);
+    super({
+      ...props,
+      points: props.data,
+    });
   }
 
-  protected draw(context: CanvasRenderingContext2D): void {
-    super.draw(context);
-
-    context.strokeStyle = resolveCanvasStyle(this.graphColor(), context);
-    context.lineWidth = this.graphWidth();
-
-    const data = this.data();
-    for (let i = 0; i < this.lastIndex(); i++) {
-      if (this.clip()) {
-        context.clip(this.getPath());
-      }
-      const baseCoord = this.getPointFromPlotSpace(data[i]);
-      const baseNextCoord = this.getPointFromPlotSpace(data[i + 1]);
-      const dir = baseCoord.sub(baseNextCoord).normalized;
-      const coord = baseCoord.add(dir.mul(this.graphWidth() / 2));
-      const nextCoord = baseNextCoord.sub(dir.mul(this.graphWidth() / 2));
-
-      context.beginPath();
-      context.moveTo(coord.x, coord.y);
-      context.lineTo(nextCoord.x, nextCoord.y);
-      context.stroke();
+  public override parsedPoints(): Vector2[] {
+    const parent = this.parent();
+    if (!(parent instanceof Plot)) {
+      useLogger().warn(
+        'Using a LinePlot outside of a Plot is the same as a Line',
+      );
+      return super.parsedPoints();
     }
+    const data = this.data().map(point => parent.getPointFromPlotSpace(point));
+    return data;
   }
 
-  public makeGraphData(
-    resolution: number,
-    f: (x: number) => number,
-  ): [number, number][] {
-    return range(this.min().x, this.max().x + resolution, resolution).map(x => [
-      x,
-      f(x),
-    ]);
+  protected childrenBBox(): BBox {
+    return BBox.fromPoints(...this.parsedPoints());
   }
 }

--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -56,16 +56,16 @@ export interface PlotProps extends LayoutProps {
   gridStrokeWidth?: SignalValue<number>;
   axisStrokeWidth?: SignalValue<number>;
 
-  xAxisColor?: SignalValue<PossibleColor>;
-  xAxisTextColor?: SignalValue<PossibleColor>;
-  xAxisLabel?: SignalValue<string>;
+  labelX?: SignalValue<string>;
+  axisColorX?: SignalValue<PossibleColor>;
+  axisTextColorX?: SignalValue<PossibleColor>;
 
-  yAxisColor?: SignalValue<PossibleColor>;
-  yAxisTextColor?: SignalValue<PossibleColor>;
-  yAxisLabel?: SignalValue<string>;
+  labelY?: SignalValue<string>;
+  axisColorY?: SignalValue<PossibleColor>;
+  axisTextColorY?: SignalValue<PossibleColor>;
 
-  xLabelFormatter?: (x: number) => string;
-  yLabelFormatter?: (y: number) => string;
+  labelFormatterX?: (x: number) => string;
+  labelFormatterY?: (y: number) => string;
 }
 
 export class Plot extends Layout {
@@ -111,30 +111,30 @@ export class Plot extends Layout {
 
   @initial('white')
   @canvasStyleSignal()
-  public declare readonly xAxisColor: CanvasStyleSignal<this>;
+  public declare readonly axisColorX: CanvasStyleSignal<this>;
 
   @initial('white')
   @canvasStyleSignal()
-  public declare readonly xAxisTextColor: CanvasStyleSignal<this>;
+  public declare readonly axisTextColorX: CanvasStyleSignal<this>;
 
   @initial('')
   @signal()
-  public declare readonly xAxisLabel: SimpleSignal<string, this>;
+  public declare readonly labelX: SimpleSignal<string, this>;
 
   @initial('white')
   @canvasStyleSignal()
-  public declare readonly yAxisColor: CanvasStyleSignal<this>;
+  public declare readonly axisColorY: CanvasStyleSignal<this>;
 
   @initial('white')
   @canvasStyleSignal()
-  public declare readonly yAxisTextColor: CanvasStyleSignal<this>;
+  public declare readonly axisTextColorY: CanvasStyleSignal<this>;
 
   @initial('')
   @signal()
-  public declare readonly yAxisLabel: SimpleSignal<string, this>;
+  public declare readonly labelY: SimpleSignal<string, this>;
 
-  public readonly xLabelFormatter: (x: number) => string;
-  public readonly yLabelFormatter: (y: number) => string;
+  public readonly labelFormatterX: (x: number) => string;
+  public readonly labelFormatterY: (y: number) => string;
 
   @computed()
   private edgePadding() {
@@ -147,8 +147,8 @@ export class Plot extends Layout {
 
   public constructor(props?: PlotProps) {
     super(props);
-    this.xLabelFormatter = props.xLabelFormatter ?? (x => x.toFixed(0));
-    this.yLabelFormatter = props.yLabelFormatter ?? (y => y.toFixed(0));
+    this.labelFormatterX = props.labelFormatterX ?? (x => x.toFixed(0));
+    this.labelFormatterY = props.labelFormatterY ?? (y => y.toFixed(0));
   }
 
   public cacheBBox(): BBox {
@@ -172,16 +172,16 @@ export class Plot extends Layout {
           this.axisStrokeWidth().x / 2,
       );
       context.lineTo(startPosition.x, halfSize.y);
-      context.strokeStyle = resolveCanvasStyle(this.xAxisColor(), context);
+      context.strokeStyle = resolveCanvasStyle(this.axisColorX(), context);
       context.lineWidth = this.gridStrokeWidth().x;
       context.stroke();
 
-      context.fillStyle = resolveCanvasStyle(this.xAxisTextColor(), context);
+      context.fillStyle = resolveCanvasStyle(this.axisTextColorX(), context);
       context.font = `${this.tickLabelSize().y}px sans-serif`;
       context.textAlign = 'center';
       context.textBaseline = 'top';
       context.fillText(
-        `${this.xLabelFormatter(this.mapToX(i / this.ticks().x))}`,
+        `${this.labelFormatterX(this.mapToX(i / this.ticks().x))}`,
         startPosition.x,
         startPosition.y +
           this.axisStrokeWidth().x +
@@ -198,16 +198,16 @@ export class Plot extends Layout {
       context.beginPath();
       context.moveTo(startPosition.x, startPosition.y);
       context.lineTo(halfSize.x - this.tickOverflow().y, startPosition.y);
-      context.strokeStyle = resolveCanvasStyle(this.yAxisColor(), context);
+      context.strokeStyle = resolveCanvasStyle(this.axisColorY(), context);
       context.lineWidth = this.gridStrokeWidth().y;
       context.stroke();
 
-      context.fillStyle = resolveCanvasStyle(this.yAxisTextColor(), context);
+      context.fillStyle = resolveCanvasStyle(this.axisTextColorY(), context);
       context.font = `${this.tickLabelSize().y}px ${this.fontFamily()}`;
       context.textAlign = 'right';
       context.textBaseline = 'middle';
       context.fillText(
-        `${this.yLabelFormatter(this.mapToY(i / this.ticks().y))}`,
+        `${this.labelFormatterY(this.mapToY(i / this.ticks().y))}`,
         halfSize.x -
           this.axisStrokeWidth().y -
           this.tickOverflow().y -
@@ -227,7 +227,7 @@ export class Plot extends Layout {
       yAxisEndPoint.x - this.gridStrokeWidth().y / 2,
       yAxisEndPoint.y + this.gridStrokeWidth().y / 2,
     );
-    context.strokeStyle = resolveCanvasStyle(this.xAxisColor(), context);
+    context.strokeStyle = resolveCanvasStyle(this.axisColorX(), context);
     context.lineWidth = this.axisStrokeWidth().x;
     context.stroke();
 
@@ -242,17 +242,17 @@ export class Plot extends Layout {
       xAxisEndPoint.x + this.gridStrokeWidth().x / 2,
       xAxisEndPoint.y + this.gridStrokeWidth().x / 2,
     );
-    context.strokeStyle = resolveCanvasStyle(this.yAxisColor(), context);
+    context.strokeStyle = resolveCanvasStyle(this.axisColorY(), context);
     context.lineWidth = this.axisStrokeWidth().y;
     context.stroke();
 
     // Draw X axis label
-    context.fillStyle = resolveCanvasStyle(this.xAxisTextColor(), context);
+    context.fillStyle = resolveCanvasStyle(this.axisTextColorX(), context);
     context.font = `${this.labelSize().y}px ${this.fontFamily()}`;
     context.textAlign = 'center';
     context.textBaseline = 'alphabetic';
     context.fillText(
-      this.xAxisLabel(),
+      this.labelX(),
       0,
       -halfSize.y +
         this.axisStrokeWidth().x +
@@ -264,7 +264,7 @@ export class Plot extends Layout {
     );
 
     // Draw rotated Y axis label
-    context.fillStyle = resolveCanvasStyle(this.yAxisTextColor(), context);
+    context.fillStyle = resolveCanvasStyle(this.axisTextColorY(), context);
     context.font = `${this.labelSize().y}px ${this.fontFamily()}`;
     context.textAlign = 'center';
     context.textBaseline = 'alphabetic';
@@ -280,7 +280,7 @@ export class Plot extends Layout {
       0,
     );
     context.rotate(-Math.PI / 2);
-    context.fillText(this.yAxisLabel(), 0, 0);
+    context.fillText(this.labelY(), 0, 0);
     context.restore();
   }
 

--- a/src/Plot.tsx
+++ b/src/Plot.tsx
@@ -18,6 +18,7 @@ import {
   SimpleSignal,
   Vector2,
   Vector2Signal,
+  range,
 } from '@motion-canvas/core';
 
 export interface PlotProps extends LayoutProps {
@@ -282,6 +283,11 @@ export class Plot extends Layout {
     context.rotate(-Math.PI / 2);
     context.fillText(this.labelY(), 0, 0);
     context.restore();
+
+    if (this.clip()) {
+      context.clip(this.getPath());
+    }
+    this.drawChildren(context);
   }
 
   public getPath(): Path2D {
@@ -311,5 +317,15 @@ export class Plot extends Layout {
 
   private toRelativeGridSize(p: PossibleVector2) {
     return new Vector2(p).sub(this.min()).div(this.max().sub(this.min()));
+  }
+
+  public makeGraphData(
+    resolution: number,
+    f: (x: number) => number,
+  ): [number, number][] {
+    return range(this.min().x, this.max().x + resolution, resolution).map(x => [
+      x,
+      f(x),
+    ]);
   }
 }

--- a/src/ScatterPlot.tsx
+++ b/src/ScatterPlot.tsx
@@ -6,18 +6,28 @@ import {
   CanvasStyleSignal,
   PossibleCanvasStyle,
   computed,
+  Layout,
+  LayoutProps,
+  parser,
 } from '@motion-canvas/2d';
-import {SimpleSignal} from '@motion-canvas/core';
-import {Plot, PlotProps} from './Plot';
+import {
+  PossibleVector2,
+  SignalValue,
+  SimpleSignal,
+  clamp,
+  useLogger,
+} from '@motion-canvas/core';
+import {Plot} from './Plot';
 
-export interface ScatterPlotProps extends PlotProps {
+export interface ScatterPlotProps extends LayoutProps {
   pointRadius?: number;
   pointColor?: PossibleCanvasStyle;
-  data?: [number, number][];
-  end?: number;
+  data?: SignalValue<PossibleVector2[]>;
+  start?: SignalValue<number>;
+  end?: SignalValue<number>;
 }
 
-export class ScatterPlot extends Plot {
+export class ScatterPlot extends Layout {
   @initial(5)
   @signal()
   public declare readonly pointRadius: SimpleSignal<number, this>;
@@ -29,23 +39,34 @@ export class ScatterPlot extends Plot {
   @signal()
   public declare readonly data: SimpleSignal<[number, number][], this>;
 
+  @initial(0)
+  @parser((value: number) => clamp(0, 1, value))
+  @signal()
+  public declare readonly start: SimpleSignal<number, this>;
+
   @initial(1)
+  @parser((value: number) => clamp(0, 1, value))
   @signal()
   public declare readonly end: SimpleSignal<number, this>;
 
   @computed()
+  private firstIndex() {
+    return Math.ceil(this.data().length * this.start() + 1);
+  }
+
+  @computed()
+  private firstPointProgress() {
+    return this.firstIndex() - this.start() * this.data().length;
+  }
+
+  @computed()
   private lastIndex() {
-    return Math.floor(
-      this.data().length * Math.min(Math.max(0, this.end()), 1) - 1,
-    );
+    return Math.floor(this.data().length * this.end() - 1);
   }
 
   @computed()
   private pointProgress() {
-    return (
-      Math.min(Math.max(this.end(), 0), 1) * this.data().length -
-      this.lastIndex()
-    );
+    return this.end() * this.data().length - this.lastIndex();
   }
 
   public constructor(props?: ScatterPlotProps) {
@@ -55,24 +76,55 @@ export class ScatterPlot extends Plot {
   }
 
   protected draw(context: CanvasRenderingContext2D): void {
-    super.draw(context);
-
     context.save();
     context.fillStyle = resolveCanvasStyle(this.pointColor(), context);
 
-    const data = this.data();
-    data.slice(0, this.lastIndex() + 1).forEach((point, i) => {
-      const coord = this.getPointFromPlotSpace(point);
+    const parent = this.parent();
+    if (!(parent instanceof Plot)) {
+      useLogger().warn('Using a ScatterPlot outside of a Plot does nothing');
+      return;
+    }
+
+    if (this.firstIndex() < this.lastIndex()) {
+      const firstPoint = this.data()[this.firstIndex() - 1];
+
+      const coord = parent.getPointFromPlotSpace(firstPoint);
+
       context.beginPath();
       context.arc(
         coord.x,
         coord.y,
-        this.pointRadius() * (i < this.lastIndex() ? 1 : this.pointProgress()),
+        this.pointRadius() * this.firstPointProgress(),
         0,
         Math.PI * 2,
       );
       context.fill();
+    }
+
+    const data = this.data();
+    data.slice(this.firstIndex(), this.lastIndex()).forEach(point => {
+      const coord = parent.getPointFromPlotSpace(point);
+
+      context.beginPath();
+      context.arc(coord.x, coord.y, this.pointRadius(), 0, Math.PI * 2);
+      context.fill();
     });
+
+    if (this.lastIndex() > this.firstIndex()) {
+      const lastPoint = data[this.lastIndex()];
+
+      const lastCoord = parent.getPointFromPlotSpace(lastPoint);
+
+      context.beginPath();
+      context.arc(
+        lastCoord.x,
+        lastCoord.y,
+        this.pointRadius() * this.pointProgress(),
+        0,
+        Math.PI * 2,
+      );
+      context.fill();
+    }
 
     context.restore();
   }

--- a/test/src/scenes/test.tsx
+++ b/test/src/scenes/test.tsx
@@ -13,8 +13,8 @@ export default makeScene2D(function* (view) {
     <LinePlot
       size={500}
       ref={plot}
-      xAxisLabel="Time"
-      yAxisLabel="Beans"
+      labelX="Time"
+      labelY="Beans"
       labelSize={10}
       graphWidth={4}
       graphColor={'red'}
@@ -46,7 +46,7 @@ export default makeScene2D(function* (view) {
       min={[-Math.PI * 2, -2]}
       end={0}
       max={[Math.PI * 2, 2]}
-      xLabelFormatter={x => `${Math.round(x / Math.PI)}π`}
+      labelFormatterX={x => `${Math.round(x / Math.PI)}π`}
       ticks={[4, 4]}
       opacity={0}
     />,
@@ -66,8 +66,8 @@ export default makeScene2D(function* (view) {
     <ScatterPlot
       size={500}
       ref={plot3}
-      xAxisLabel="Time"
-      yAxisLabel="Errors"
+      labelX="Time"
+      labelY="Errors"
       labelSize={10}
       pointRadius={5}
       pointColor={'red'}

--- a/test/src/scenes/test.tsx
+++ b/test/src/scenes/test.tsx
@@ -10,17 +10,21 @@ export default makeScene2D(function* (view) {
 
   const plot = createRef<Plot>();
   view.add(
-    <LinePlot
+    <Plot
       size={500}
       ref={plot}
       labelX="Time"
       labelY="Beans"
       labelSize={10}
-      graphWidth={4}
-      graphColor={'red'}
       opacity={0}
-      data={range(0, 26).map(i => [i * 4, random.nextInt(0, 100)])}
-    />,
+    >
+      <LinePlot
+        lineWidth={4}
+        stroke={'red'}
+        data={range(0, 26).map(i => [i * 4, random.nextInt(0, 100)])}
+      />
+      ,
+    </Plot>,
   );
 
   yield* plot().opacity(1, 2);
@@ -34,78 +38,87 @@ export default makeScene2D(function* (view) {
   yield* plot().opacity(0, 2);
   plot().remove();
 
-  const plot2 = createRef<LinePlot>();
+  const plot2 = createRef<Plot>();
+  const line2 = createRef<LinePlot>();
   view.add(
-    <LinePlot
+    <Plot
       clip
       size={500}
       ref={plot2}
       labelSize={0}
-      graphWidth={4}
-      graphColor={'red'}
       min={[-Math.PI * 2, -2]}
-      end={0}
       max={[Math.PI * 2, 2]}
       labelFormatterX={x => `${Math.round(x / Math.PI)}π`}
       ticks={[4, 4]}
       opacity={0}
-    />,
+    >
+      <LinePlot lineWidth={4} stroke={'red'} end={0} ref={line2} />
+    </Plot>,
   );
 
-  plot2().data(plot2().makeGraphData(0.1, x => Math.sin(x)));
+  line2().data(plot2().makeGraphData(0.1, x => Math.sin(x)));
 
   yield* plot2().opacity(1, 2);
   yield* waitFor(2);
-  yield* plot2().end(1, 1);
+  yield* line2().end(1, 1);
   yield* waitFor(3);
 
   yield* plot2().opacity(0, 2);
 
-  const plot3 = createRef<ScatterPlot>();
+  const plot3 = createRef<Plot>();
+  const scatter3 = createRef<ScatterPlot>();
   view.add(
-    <ScatterPlot
+    <Plot
       size={500}
       ref={plot3}
       labelX="Time"
       labelY="Errors"
       labelSize={10}
-      pointRadius={5}
-      pointColor={'red'}
       opacity={0}
-      end={0}
-      data={range(0, 26).map(i => [i * 4, random.nextInt(0, 100)])}
-    />,
+    >
+      <ScatterPlot
+        pointRadius={5}
+        pointColor={'red'}
+        ref={scatter3}
+        start={0.5}
+        end={0.5}
+        data={range(0, 26).map(i => [i * 4, random.nextInt(0, 100)])}
+      />
+    </Plot>,
   );
 
   yield* plot3().opacity(1, 2);
   yield* waitFor(2);
-  yield* plot3().end(1, 3, linear);
+  yield scatter3().end(1, 3, linear);
+  yield* waitFor(0.1);
+  yield* scatter3().start(0, 3, linear);
   yield* waitFor(2);
   yield* plot3().opacity(0, 2);
 
-  const plot4 = createRef<LinePlot>();
+  const plot4 = createRef<Plot>();
+  const line4 = createRef<LinePlot>();
   view.add(
-    <LinePlot
+    <Plot
       clip
       size={500}
       ref={plot4}
       labelSize={0}
-      graphWidth={4}
-      graphColor={'red'}
       minX={-10}
       maxX={10}
       minY={-2}
       maxY={50}
-      end={0}
       opacity={0}
       ticks={[4, 4]}
-    />,
+      offset={[-1, 0]}
+    >
+      <LinePlot lineWidth={4} stroke={'red'} ref={line4} />
+    </Plot>,
   );
 
-  plot4().data(plot4().makeGraphData(0.1, x => Math.pow(x, 2)));
+  line4().data(plot4().makeGraphData(0.1, x => Math.pow(x, 2)));
   yield* plot4().opacity(1, 2);
   yield* waitFor(2);
-  yield* plot4().end(1, 1);
+  yield* line4().end(1, 1);
 
   yield* waitFor(5);
 });

--- a/test/src/scenes/test.tsx
+++ b/test/src/scenes/test.tsx
@@ -27,7 +27,8 @@ export default makeScene2D(function* (view) {
   yield* waitFor(2);
 
   yield* plot().ticks(20, 3);
-  yield* plot().size(1000, 2);
+  yield* plot().tickLabelSize(20, 2);
+  yield* plot().size(800, 2);
   yield* plot().labelSize(30, 2);
   yield* plot().min(-100, 2);
   yield* plot().opacity(0, 2);


### PR DESCRIPTION
Changes:
* Use the node size for the plot size (Closes #7)
* Make property names consistent (`propertyX` rather than `xProperty`)
* Make line and scatter plot child nodes
* Bump version to 2.0.0

